### PR TITLE
feat: Added Selling Feature by Cancelling Active Stop-Loss Order

### DIFF
--- a/AutoTraderApp.Application/Features/Strategies/Commands/ApplyStrategyToMultipleStocksSync/ApplyStrategyToMultipleStocksSyncCommand.cs
+++ b/AutoTraderApp.Application/Features/Strategies/Commands/ApplyStrategyToMultipleStocksSync/ApplyStrategyToMultipleStocksSyncCommand.cs
@@ -85,29 +85,29 @@ namespace AutoTraderApp.Application.Features.Strategies.Commands.ApplyStrategyTo
             //**********//Hisse listeleri güncelleniyor && çağırılıyor//**********//
 
             // UpdateCombinedStockListCommand çalıştırılıyor
-            var updateResult = _mediator.Send(new UpdateCombinedStockListCommand()).Result;
-            if (!updateResult)
-            {
-                return new ErrorResult(Messages.General.Updated);
-            }
+            ////var updateResult = _mediator.Send(new UpdateCombinedStockListCommand()).Result;
+            //if (!updateResult)
+            //{
+            //    return new ErrorResult(Messages.General.Updated);
+            //}
 
-            var combinedStocks = _combinedStockRepository.GetAllAsync().Result;
-            if (combinedStocks == null || !combinedStocks.Any())
-            {
-                return new ErrorResult(Messages.General.DataNotFound);
-            }
+            //var combinedStocks = _combinedStockRepository.GetAllAsync().Result;
+            //if (combinedStocks == null || !combinedStocks.Any())
+            //{
+            //    return new ErrorResult(Messages.General.DataNotFound);
+            //}
 
-            var nasdaqStocks = _alphaVantageService.GetNasdaqListingsAsync(500).Result;
-            if (nasdaqStocks == null)
-            {
-                return new ErrorResult(Messages.General.DataNotFound);
-            }
+            //var nasdaqStocks = _alphaVantageService.GetNasdaqListingsAsync(500).Result;
+            //if (nasdaqStocks == null)
+            //{
+            //    return new ErrorResult(Messages.General.DataNotFound);
+            //}
 
-            var customStocks = _customStockRepository.GetAllAsync().Result;
-            if (customStocks == null)
-            {
-                return new ErrorResult(Messages.General.DataNotFound);
-            }
+            //var customStocks = _customStockRepository.GetAllAsync().Result;
+            //if (customStocks == null)
+            //{
+            //    return new ErrorResult(Messages.General.DataNotFound);
+            //}
 
             var cryptoCustomStocks = _cryptoCustomStockRepository.GetAllAsync().Result;
             if (cryptoCustomStocks == null)

--- a/AutoTraderApp.Application/Features/TradingView/Commands/CryptoProcessTradingViewSignal/CryptoProcessTradingViewSignalCommand.cs
+++ b/AutoTraderApp.Application/Features/TradingView/Commands/CryptoProcessTradingViewSignal/CryptoProcessTradingViewSignalCommand.cs
@@ -53,7 +53,6 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
                 var cryptoPrice = await _binanceService.GetMarketPriceAsync(signal.Symbol, brokerAccount.Id);
                 if (cryptoPrice <= 0)
                 {
-                    Console.WriteLine($"****************SWMBOL {signal.Symbol} {cryptoPrice}");
                     await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, cryptoPrice, null, "HATA: FİYAT BİLGİSİ BULUNAMADI");
                     return new ErrorResult(Messages.Trading.PriceNotFound);
                 }
@@ -67,7 +66,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
 
                 if (lotSizeFilter == null || minNotionalFilter == null)
                 {
-                    await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, null, Messages.Trading.FilterNotFound);
+                    await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, null, Messages.Trading.FilterNotFound);
                     return new ErrorResult(Messages.Trading.FilterNotFound);
                 }
 
@@ -81,7 +80,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
                     var position = await _binanceService.GetCryptoPositionAsync(signal.Symbol, brokerAccount.Id);
                     if (position == null || position.Quantity <= 0)
                     {
-                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, null, Messages.Trading.FilterNotFound);
+                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, null, Messages.Trading.FilterNotFound);
                         return new ErrorResult(Messages.Trading.NoPositionToSell);
                     }
 
@@ -113,17 +112,17 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
                     }
 
 
-                    //if (sellQuantity < minQtySell)
-                    //{
-                    //    await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, Convert.ToInt32(sellQuantity), $"⚠️ Yetersiz bakiye: {sellQuantity}. Minimum LOT_SIZE: {minQtySell}. Satış yapılamaz.");
-                    //    return new ErrorResult($"⚠️ Yetersiz bakiye: {sellQuantity}. Minimum LOT_SIZE: {minQtySell}. Satış yapılamaz.");
-                    //}
+                    if (sellQuantity < minQtySell)
+                    {
+                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, Convert.ToInt32(sellQuantity), $"⚠️ Yetersiz bakiye: {sellQuantity}. Minimum LOT_SIZE: {minQtySell}. Satış yapılamaz.");
+                        return new ErrorResult($"⚠️ Yetersiz bakiye: {sellQuantity}. Minimum LOT_SIZE: {minQtySell}. Satış yapılamaz.");
+                    }
 
                     sellQuantity = Math.Floor(sellQuantity / stepSizeSell) * stepSizeSell;
 
                     if (sellQuantity * cryptoPrice < minNotionalSell)
                     {
-                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, null, $"⚠️ İşlem tutarı çok düşük. Minimum {minNotionalSell} USDT değerinde işlem yapılmalı.");
+                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, null, $"⚠️ İşlem tutarı çok düşük. Minimum {minNotionalSell} USDT değerinde işlem yapılmalı.");
                         return new ErrorResult($"⚠️ İşlem tutarı çok düşük. Minimum {minNotionalSell} USDT değerinde işlem yapılmalı.");
                     }
 
@@ -138,7 +137,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
 
                     if (!sellOrderResult)
                     {
-                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, Convert.ToInt32(sellQuantity), Messages.Trading.OrderFailed);
+                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, Convert.ToInt32(sellQuantity), Messages.Trading.OrderFailed);
                         return new ErrorResult(Messages.Trading.OrderFailed);
                     }
 
@@ -147,7 +146,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
                         $"✅ **Satış tamamlandı:** {signal.Symbol}, **Miktar:** {sellQuantity} USDT"
                     );
 
-                    await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, Convert.ToInt32(sellQuantity), Messages.General.Success);
+                    await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, Convert.ToInt32(sellQuantity), Messages.General.Success);
                     return new SuccessResult(Messages.General.Success);
                 }
 
@@ -157,7 +156,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
                     var accountBalance = await _binanceService.GetAccountBalanceAsync(brokerAccount.Id);
                     if (accountBalance <= 0)
                     {
-                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, null, Messages.Trading.PriceNotFound);
+                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, null, Messages.Trading.PriceNotFound);
                         return new ErrorResult(Messages.Trading.PriceNotFound);
                     }
 
@@ -166,7 +165,8 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
                         userTradingSettings.RiskPercentage,
                         cryptoPrice,
                         userTradingSettings.MaxRiskLimit,
-                        userTradingSettings.MaxBuyQuantity
+                        userTradingSettings.MaxBuyQuantity,
+                        userTradingSettings.MinBuyPrice
                     );
 
                     // **Binance LOT_SIZE uygunluğu kontrolü**
@@ -186,7 +186,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
 
                         if (minRequiredQty * cryptoPrice > accountBalance)
                         {
-                            await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, null, $"Yetersiz bakiye. Minimum {minNotional} USDT değerinde işlem yapılmalı.");
+                            await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, null, $"Yetersiz bakiye. Minimum {minNotional} USDT değerinde işlem yapılmalı.");
                             return new ErrorResult($"Yetersiz bakiye. Minimum {minNotional} USDT değerinde işlem yapılmalı.");
                         }
 
@@ -203,7 +203,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
 
                     if (!buyOrderResult)
                     {
-                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, null, Messages.Trading.OrderFailed);
+                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, null, Messages.Trading.OrderFailed);
                         return new ErrorResult(Messages.Trading.OrderFailed);
                     }
 
@@ -232,7 +232,7 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
 
                     if (!stopLossResult)
                     {
-                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, Convert.ToInt32(calculatedQuantity), Messages.Trading.StopLossOrderFailed);
+                        await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, Convert.ToInt32(calculatedQuantity), Messages.Trading.StopLossOrderFailed);
                         return new ErrorResult(Messages.Trading.StopLossOrderFailed);
                     }
 
@@ -240,13 +240,13 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.CryptoProcessT
                         signal.UserId.ToString(),
                         $"🟢 Alım tamamlandı: {signal.Symbol}, Miktar: {calculatedQuantity} USDT. Stop-loss {stopLossPrice} olarak ayarlandı."
                     );
-                    await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, Convert.ToInt32(calculatedQuantity), Messages.General.Success);
+                    await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, Convert.ToInt32(calculatedQuantity), Messages.General.Success);
                     return new SuccessResult(Messages.General.Success);
                 }
             }
             catch (Exception ex)
             {
-                await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Action, signal.Symbol, null, null, $"{Messages.General.SystemError}: {ex.Message}");
+                await _binanceService.BinanceLog(signal.BrokerAccountId, signal.Symbol, signal.Action, null, null, $"{Messages.General.SystemError}: {ex.Message}");
                 return new ErrorResult($"{Messages.General.SystemError}: {ex.Message}");
             }
         }

--- a/AutoTraderApp.Application/Features/TradingView/Commands/StockProcessTradingViewSignal/StockProcessTradingViewSignalCommand.cs
+++ b/AutoTraderApp.Application/Features/TradingView/Commands/StockProcessTradingViewSignal/StockProcessTradingViewSignalCommand.cs
@@ -115,7 +115,8 @@ namespace AutoTraderApp.Application.Features.TradingView.Commands.StockProcessTr
                         stopLoss,
                         userTradingSettings.MaxRiskLimit,
                         userTradingSettings.MinBuyQuantity,
-                        userTradingSettings.MaxBuyQuantity
+                        userTradingSettings.MaxBuyQuantity,
+                        userTradingSettings.MinBuyPrice
                     );
 
                     signalTotalCost = signal.Quantity * price;

--- a/AutoTraderApp.Application/Features/UserTradingSettings/Commands/CreateUserTradingSettingsCommand.cs
+++ b/AutoTraderApp.Application/Features/UserTradingSettings/Commands/CreateUserTradingSettingsCommand.cs
@@ -3,9 +3,6 @@ using AutoTraderApp.Core.Utilities.Repositories;
 using AutoTraderApp.Core.Utilities.Results;
 using AutoTraderApp.Domain.Entities;
 using MediatR;
-using System.Threading.Tasks;
-using System.Threading;
-using System;
 
 namespace AutoTraderApp.Application.Features.UserTradingSettings.Commands
 {
@@ -13,7 +10,7 @@ namespace AutoTraderApp.Application.Features.UserTradingSettings.Commands
     {
         public Guid UserId { get; set; }
         public string BrokerType { get; set; }
-        public UserTradingSettingsDto Settings { get; set; }
+        public UserTradingSettingsCreateDto Settings { get; set; }
     }
 
     public class CreateUserTradingSettingsCommandHandler : IRequestHandler<CreateUserTradingSettingsCommand, IResult>

--- a/AutoTraderApp.Application/Features/UserTradingSettings/Commands/UpdateUserTradingSettingsCommand.cs
+++ b/AutoTraderApp.Application/Features/UserTradingSettings/Commands/UpdateUserTradingSettingsCommand.cs
@@ -13,7 +13,7 @@ namespace AutoTraderApp.Application.Features.UserTradingSettings.Commands
     {
         public Guid UserId { get; set; }
         public string BrokerType { get; set; }
-        public UserTradingSettingsDto Settings { get; set; }
+        public UserTradingSettingsCreateDto Settings { get; set; }
     }
 
     public class UpdateUserTradingSettingsCommandHandler : IRequestHandler<UpdateUserTradingSettingsCommand, IResult>

--- a/AutoTraderApp.Application/Features/UserTradingSettings/DTOs/UserTradingSettingsCreateDto.cs
+++ b/AutoTraderApp.Application/Features/UserTradingSettings/DTOs/UserTradingSettingsCreateDto.cs
@@ -1,0 +1,13 @@
+﻿namespace AutoTraderApp.Application.Features.UserTradingSettings.DTOs
+{
+    public class UserTradingSettingsCreateDto
+    {
+        public string UserName { get; set; }
+        public decimal RiskPercentage { get; set; }
+        public decimal MaxRiskLimit { get; set; }
+        public int MinBuyQuantity { get; set; }
+        public int MaxBuyQuantity { get; set; }
+        public decimal BuyPricePercentage { get; set; }
+        public decimal SellPricePercentage { get; set; }
+    }
+}

--- a/AutoTraderApp.Core/Utilities/Calculators/QuantityCalculator.cs
+++ b/AutoTraderApp.Core/Utilities/Calculators/QuantityCalculator.cs
@@ -13,7 +13,14 @@ namespace AutoTraderApp.Core.Utilities.Calculators
         /// <param name="entryPrice">Giriş fiyatı.</param>
         /// <param name="stopLoss">Zararı durdurma fiyatı.</param>
         /// <returns>Alınabilecek hisse miktarı.</returns>
-        public static int StockCalculateQuantity(decimal accountValue, decimal riskPercentage, decimal entryPrice, decimal stopLoss, decimal maxBuyingPowerPercent, int minBuyQuantity, int maxBuyQuantity)
+        public static int StockCalculateQuantity(
+            decimal accountValue, 
+            decimal riskPercentage, 
+            decimal entryPrice, decimal stopLoss,
+            decimal maxBuyingPowerPercent, 
+            int minBuyQuantity, 
+            int maxBuyQuantity,
+            decimal minBuyPrice)
         {
             if (entryPrice <= stopLoss)
             {
@@ -30,16 +37,13 @@ namespace AutoTraderApp.Core.Utilities.Calculators
                 throw new ArgumentException("Stop-loss seviyesi giriş fiyatından büyük olamaz.");
             }
 
-            // Hesaplanan miktarı bul
             int quantity = (int)(Math.Floor(riskAmount / perUnitRisk));
 
-            // Toplam fiyatı hesapla
-            decimal totalPrice = quantity * entryPrice;
+            decimal totalPrice = quantity * entryPrice; 
 
-            // Eğer toplam fiyat 2500 doların altındaysa, miktarı artır
-            if (totalPrice < 2500)
+            if (totalPrice < minBuyPrice)
             {
-                quantity = (int)Math.Ceiling(2500 / entryPrice);
+                quantity = (int)Math.Ceiling(minBuyPrice / entryPrice);
             }
 
             // Maksimum alım gücüne göre miktarı sınırla
@@ -67,7 +71,8 @@ namespace AutoTraderApp.Core.Utilities.Calculators
            decimal riskPercentage,
            decimal cryptoPrice,
            decimal maxRiskLimit,
-           decimal maxBuyQuantity)
+           decimal maxBuyQuantity,
+           decimal minBuyPrice)
         {
             decimal riskAmount = accountBalance * riskPercentage;
 
@@ -81,6 +86,13 @@ namespace AutoTraderApp.Core.Utilities.Calculators
             if (quantity > maxBuyQuantity)
             {
                 quantity = maxBuyQuantity;
+            }
+
+            decimal totalPrice = quantity * cryptoPrice;
+
+            if (totalPrice < minBuyPrice)
+            {
+                quantity = Math.Ceiling(minBuyPrice / cryptoPrice);
             }
 
             return Math.Round(quantity, 8);

--- a/AutoTraderApp.Domain/Entities/UserTradingSettings.cs
+++ b/AutoTraderApp.Domain/Entities/UserTradingSettings.cs
@@ -48,5 +48,6 @@ namespace AutoTraderApp.Domain.Entities
         public decimal BuyPricePercentage { get; set; } = 0.98m;
 
         public decimal SellPricePercentage { get; set; } = 0.98m;
+        public decimal MinBuyPrice { get; set; } = 30;
     }
 }

--- a/AutoTraderApp.Infrastructure/Interfaces/IBinanceService.cs
+++ b/AutoTraderApp.Infrastructure/Interfaces/IBinanceService.cs
@@ -35,6 +35,8 @@ namespace AutoTraderApp.Infrastructure.Interfaces
         Task<decimal> AdjustQuantityForBinance(string symbol, decimal requestedQuantity, decimal price, Guid brokerAccountId, bool isSellOrder);
         Task<BinancePosition?> GetCryptoPositionAsync(string symbol, Guid brokerAccountId);
         Task<bool> BinanceLog(Guid brokerAccountId, string symbol, string? Action, decimal? price, int? quantity, string msg);
+        Task<BinanceOrder?> GetActiveStopLossOrderAsync(Guid brokerAccountId, string symbol);
+        Task<bool> CancelOrderAsync(Guid brokerAccountId, string symbol, string orderId);
     }
 
 }

--- a/AutoTraderApp.Persistence/Migrations/20250126183417_AddUserTradingSettings.cs
+++ b/AutoTraderApp.Persistence/Migrations/20250126183417_AddUserTradingSettings.cs
@@ -17,6 +17,7 @@ namespace AutoTraderApp.Persistence.Migrations
                 {
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    BrokerType = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     RiskPercentage = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
                     MaxRiskLimit = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
                     MinBuyQuantity = table.Column<int>(type: "int", nullable: false),

--- a/AutoTraderApp.Persistence/Migrations/20250203202402_UpdateUserTradingSettingMinSellPrice.Designer.cs
+++ b/AutoTraderApp.Persistence/Migrations/20250203202402_UpdateUserTradingSettingMinSellPrice.Designer.cs
@@ -4,6 +4,7 @@ using AutoTraderApp.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AutoTraderApp.Persistence.Migrations
 {
     [DbContext(typeof(AutoTraderAppDbContext))]
-    partial class AutoTraderAppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250203202402_UpdateUserTradingSettingMinSellPrice")]
+    partial class UpdateUserTradingSettingMinBuyPrice
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AutoTraderApp.Persistence/Migrations/20250203202402_UpdateUserTradingSettingMinSellPrice.cs
+++ b/AutoTraderApp.Persistence/Migrations/20250203202402_UpdateUserTradingSettingMinSellPrice.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutoTraderApp.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateUserTradingSettingMinBuyPrice : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "MinBuyPrice",
+                table: "UserTradingSettings",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MinBuyPrice",
+                table: "UserTradingSettings");
+        }
+    }
+}

--- a/AutoTraderApp.WebAPI/Controllers/BinanceController.cs
+++ b/AutoTraderApp.WebAPI/Controllers/BinanceController.cs
@@ -29,6 +29,20 @@ namespace AutoTraderApp.API.Controllers
             }
         }
 
+        [HttpGet]
+        public async Task<IActionResult> GetMarketPriceAsync(Guid brokerAccountId, string Symbol)
+        {
+            try
+            {
+                var accountInfo = await _binanceService.GetMarketPriceAsync(Symbol,brokerAccountId);
+                return Ok(new { success = true, data = accountInfo });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { success = false, message = ex.Message });
+            }
+        }
+
         [HttpGet("account/total/balance/{brokerAccountId}")]
         public async Task<IActionResult> GetTotalBalance(Guid brokerAccountId)
         {


### PR DESCRIPTION
-When the sell signal comes, if there is an active Stop Loss order, it will be canceled in advance.
- Once the Stop Loss order is successfully canceled, the entire amount of the relevant crypto will be sold via market order.
- If the Stop Loss cannot be canceled, the transaction returns as unsuccessful.
- Added `GetActiveStopLossOrderAsync` method to get active Stop-Loss order via Binance API.
- Added `CancelOrderAsync` method to cancel orders via Binance API.
- Checking LOT_SIZE and MinNotional checks to ensure that orders are valid.

With this commitment, cancellation of existing Stop-Loss orders and subsequent market selling of sell rates were automated.